### PR TITLE
Fix index-state syntax

### DIFF
--- a/cabal.ghc9.project
+++ b/cabal.ghc9.project
@@ -14,8 +14,9 @@ package plutonomy
 -- plutus dependencies
 ----------------------------------------------------------------------------
 
-index-state: 2022-10-31T00:00:00Z
-index-state: cardano-haskell-packages 2022-10-31T00:00:00Z
+index-state:
+  , hackage.haskell.org 2022-10-31T00:00:00Z
+  , cardano-haskell-packages 2022-10-31T00:00:00Z
 
 with-compiler: ghc-9.2.4
 


### PR DESCRIPTION
The second index-state stanza completely ovverides the first, resetting hackage index state to HEAD. See haskell/cabal#8568